### PR TITLE
Add styling for DEM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 0.11 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Add rasters.
 
 
 0.10 (2017-10-19)

--- a/layer_styles/DEM Netherlands.qml
+++ b/layer_styles/DEM Netherlands.qml
@@ -1,0 +1,20 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis version="2.14.20-Essen" minimumScale="-4.65661e-10" maximumScale="1e+08" hasScaleBasedVisibilityFlag="0">
+  <pipe>
+    <rasterrenderer opacity="1" alphaBand="0" classificationMax="57.8495" classificationMinMaxOrigin="CumulativeCutFullExtentEstimated" band="1" classificationMin="-4.4585" type="singlebandpseudocolor">
+      <rasterTransparency/>
+      <rastershader>
+        <colorrampshader colorRampType="INTERPOLATED" clip="0">
+          <item alpha="204" value="-5.72" label="-5.72" color="#2d7d83"/>
+          <item alpha="255" value="0" label="0" color="#9dc9b7"/>
+          <item alpha="255" value="1" label="1" color="#ffffcc"/>
+          <item alpha="205" value="30" label="30" color="#b05c17"/>
+        </colorrampshader>
+      </rastershader>
+    </rasterrenderer>
+    <brightnesscontrast brightness="0" contrast="0"/>
+    <huesaturation colorizeGreen="128" colorizeOn="0" colorizeRed="255" colorizeBlue="128" grayscaleMode="0" saturation="0" colorizeStrength="100"/>
+    <rasterresampler maxOversampling="2"/>
+  </pipe>
+  <blendMode>0</blendMode>
+</qgis>

--- a/lizard_viewer.py
+++ b/lizard_viewer.py
@@ -26,6 +26,7 @@ from .utils.constants import RASTER_TYPES
 from .utils.constants import ERROR_LEVEL_CRITICAL
 from .utils.constants import ERROR_LEVEL_SUCCESS
 from .utils.constants import ERROR_LEVEL_WARNING
+from .utils.constants import STYLES_ROOT
 from .utils.get_data import retrieve_data_from_lizard
 from .utils.geometry import add_area_filter
 from .utils.geometry import get_bbox
@@ -384,6 +385,11 @@ class LizardViewer:
         else:
             show_message(
                 "Failed to download %s" % data['layer'], ERROR_LEVEL_CRITICAL)
+        qml_path = os.path.join(STYLES_ROOT, "{}.qml".format(data['layer']))
+        if os.path.exists(qml_path):
+            self.iface.activeLayer().loadNamedStyle(qml_path)
+            self.iface.legendInterface().refreshLayerSymbology(
+                self.iface.activeLayer())
 
     def show_login_dialog(self):
         """Function to show the login dialog."""

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -20,13 +20,13 @@ ASSET_GEOMETRY_TYPES = {"bridges": "Point", "culverts": "LineString",
                         "pumpstations": "Point", "sluices": "Point",
                         "wastewatertreatmentplants": "Point", "weirs": "Point"}
 RASTER_TYPES = [
-    'DEM (Netherlands)',
+    'DEM Netherlands',
     'Land use (old)',
     'NDVI (Flevoland)'
 ]
 
 RASTER_INFO = {
-    'DEM (Netherlands)': {
+    'DEM Netherlands': {
         'uuid': '1d65a4e1-ac2f-4e66-9e52-1d130d870a34',
         'temporal': False
     },

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -20,21 +20,21 @@ ASSET_GEOMETRY_TYPES = {"bridges": "Point", "culverts": "LineString",
                         "pumpstations": "Point", "sluices": "Point",
                         "wastewatertreatmentplants": "Point", "weirs": "Point"}
 RASTER_TYPES = [
-    'dem:nl',
-    'extern:nl:flevoland',
-    'cover:fun',
+    'DEM (Netherlands)',
+    'Land use (old)',
+    'NDVI (Flevoland)'
 ]
 
 RASTER_INFO = {
-    'dem:nl': {
+    'DEM (Netherlands)': {
         'uuid': '1d65a4e1-ac2f-4e66-9e52-1d130d870a34',
         'temporal': False
     },
-    'extern:nl:flevoland': {
+    'NDVI (Flevoland)': {
         'uuid': '920937b3-478c-4cac-bbd1-350ca6d52eff',
         'temporal': True,
     },
-    'cover:fun': {
+    'Land use (old)': {
         'uuid': 'b92c5c3a-854e-47b8-a083-ae9bf1760496',
         'temporal': False,
     }

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -21,8 +21,8 @@ ASSET_GEOMETRY_TYPES = {"bridges": "Point", "culverts": "LineString",
                         "wastewatertreatmentplants": "Point", "weirs": "Point"}
 RASTER_TYPES = [
     'DEM Netherlands',
-    'Land use (old)',
-    'NDVI (Flevoland)'
+    'Land use old',
+    'NDVI Flevoland'
 ]
 
 RASTER_INFO = {
@@ -30,11 +30,11 @@ RASTER_INFO = {
         'uuid': '1d65a4e1-ac2f-4e66-9e52-1d130d870a34',
         'temporal': False
     },
-    'NDVI (Flevoland)': {
+    'NDVI Flevoland': {
         'uuid': '920937b3-478c-4cac-bbd1-350ca6d52eff',
         'temporal': True,
     },
-    'Land use (old)': {
+    'Land use old': {
         'uuid': 'b92c5c3a-854e-47b8-a083-ae9bf1760496',
         'temporal': False,
     }

--- a/utils/rasters.py
+++ b/utils/rasters.py
@@ -67,8 +67,8 @@ class BoundingBox(object):
 
 
 def fetch_layer_from_server(
-        bbox, width, height, dt=None, srs='epsg:4326', layer='dem:nl',
-        username=None, password=None,
+        bbox, width, height, dt=None, srs='epsg:4326',
+        layer='DEM (Netherlands)', username=None, password=None,
         server='https://demo.lizard.net/api/v3/rasters/'):
     """
     Fetches rain data from raster server.

--- a/utils/rasters.py
+++ b/utils/rasters.py
@@ -68,7 +68,7 @@ class BoundingBox(object):
 
 def fetch_layer_from_server(
         bbox, width, height, dt=None, srs='epsg:4326',
-        layer='DEM (Netherlands)', username=None, password=None,
+        layer='DEM Netherlands', username=None, password=None,
         server='https://demo.lizard.net/api/v3/rasters/'):
     """
     Fetches rain data from raster server.


### PR DESCRIPTION
* Refer to rasters with name instead of slug.
* Remove parenthesis of names to be able to create qml's with the same name
* Add qml as styling for DEM